### PR TITLE
Export img

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,6 +61,11 @@ class MainWidget(QWidget):
         self.layout.addWidget(self.render_btn, 2, 1)
         self.render_btn.setEnabled(False)
 
+        self.export_btn = QPushButton("Exporter en image")
+        self.export_btn.clicked.connect(self.export_image)
+        self.layout.addWidget(self.export_btn, 2, 2)
+        self.export_btn.setEnabled(False)
+
         self.update_status_tip()
 
         self.show()
@@ -112,6 +117,7 @@ class MainWidget(QWidget):
             return
 
         self.render_btn.setEnabled(True)
+        self.export_btn.setEnabled(True)
 
     def update_status_tip(self):
         """
@@ -140,6 +146,9 @@ class MainWidget(QWidget):
 
         self.parent().statusBar().showMessage("Dessiner le pavage")
 
+    def export_image(self):
+        """Capture le pavage actuel et l'exporte en image."""
+        return #TO-DO
 
 class MainWindow(QMainWindow):
 
@@ -345,6 +354,7 @@ class HelpWindow(QDialog):
                 <li>Charger une image ou la dessiner pour la tuiler</li>
                 <li>Choisir un type de pavage (sphérique, euclidien, hyperbolique)</li>
                 <li>Dessiner un pavage</li>
+                <li>Exporter le pavage en image</li>
             </ul>
 
             <h3>Raccourcis clavier :</h3>

--- a/main.py
+++ b/main.py
@@ -61,11 +61,6 @@ class MainWidget(QWidget):
         self.layout.addWidget(self.render_btn, 2, 1)
         self.render_btn.setEnabled(False)
 
-        self.export_btn = QPushButton("Exporter en image")
-        self.export_btn.clicked.connect(self.export_image)
-        self.layout.addWidget(self.export_btn, 2, 2)
-        self.export_btn.setEnabled(False)
-
         self.update_status_tip()
 
         self.show()
@@ -117,7 +112,6 @@ class MainWidget(QWidget):
             return
 
         self.render_btn.setEnabled(True)
-        self.export_btn.setEnabled(True)
 
     def update_status_tip(self):
         """
@@ -145,10 +139,6 @@ class MainWidget(QWidget):
             return
 
         self.parent().statusBar().showMessage("Dessiner le pavage")
-
-    def export_image(self):
-        """Capture le pavage actuel et l'exporte en image."""
-        return #TO-DO
 
 class MainWindow(QMainWindow):
 

--- a/tilings/abstract/tiling.py
+++ b/tilings/abstract/tiling.py
@@ -1,11 +1,15 @@
 from abc import abstractmethod
+
+import tkinter as tk
+from tkinter import filedialog
+
 from typing import List
 from OpenGL import GL
 from PySide6.QtCore import QSize, QPointF
 from PySide6.QtGui import QImage
 from PySide6.QtOpenGL import QOpenGLShaderProgram, QOpenGLShader, QOpenGLTexture
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QFileDialog
 from numpy import array, float32
 from utils.path_helper import get_resource_path
 
@@ -157,7 +161,20 @@ class Tiling(QWidget):
         """
         Capture l'image du pavage et l'enregistre sous forme d'image.
         """ 
-        return #To-Do
+        root = tk.Tk()
+        root.withdraw()  # Masquer la fenêtre principale Tkinter
+        file_path = filedialog.asksaveasfilename(
+            defaultextension=".png",
+            filetypes=[("Images PNG", "*.png"), ("Images JPG", "*.jpg")],
+            title="Exporter l'image")
+
+        if not file_path:  # Si l'utilisateur annule
+            return
+        
+        screen = self.drawing.window().screen()
+        pixmap = screen.grabWindow(self.drawing.winId())
+
+        pixmap.save(file_path)
 
     def reset_tiling(self, new_corners):
         """

--- a/tilings/abstract/tiling.py
+++ b/tilings/abstract/tiling.py
@@ -1,12 +1,11 @@
 from abc import abstractmethod
 from typing import List
-
 from OpenGL import GL
 from PySide6.QtCore import QSize, QPointF
 from PySide6.QtGui import QImage
 from PySide6.QtOpenGL import QOpenGLShaderProgram, QOpenGLShader, QOpenGLTexture
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
-from PySide6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton
 from numpy import array, float32
 from utils.path_helper import get_resource_path
 
@@ -141,6 +140,9 @@ class Tiling(QWidget):
 
         self.resolution = resolution if resolution is not None else QSize(600, 600)
         self.setWindowTitle(self.KIND)
+        
+        self.export_button = QPushButton("Exporter l'image", self)
+        self.export_button.clicked.connect(self.export_image)
 
         self.options = self.OPTIONS_CLASS.init(self)
         self.drawing = self.DRAWING_CLASS.init(self, path, img_size, corners)
@@ -149,6 +151,13 @@ class Tiling(QWidget):
         self.setLayout(self.layout)
         self.layout.addWidget(self.drawing)
         self.layout.addWidget(self.options)
+        self.layout.addWidget(self.export_button)
+        
+    def export_image(self):
+        """
+        Capture l'image du pavage et l'enregistre sous forme d'image.
+        """ 
+        return #To-Do
 
     def reset_tiling(self, new_corners):
         """


### PR DESCRIPTION
Ajout de la fonctionnalité d'export du pavage généré en image png. 
L'utilisateur peut accéder à cette fonctionnalité depuis la fenêtre de rendu, en cliquant sur le bouton "Exporter l'image".